### PR TITLE
이미지 업로드 이슈 처리

### DIFF
--- a/CommunitySite/pom.xml
+++ b/CommunitySite/pom.xml
@@ -15,6 +15,22 @@
 		<org.apache.tiles-version>3.0.3</org.apache.tiles-version>
 	</properties>
 	<dependencies>
+		<!-- file upload -->
+		<!-- https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload -->
+		<!-- Multipart Resolver -->
+		<dependency>
+		    <groupId>commons-fileupload</groupId>
+		    <artifactId>commons-fileupload</artifactId>
+		    <version>1.4</version>
+		</dependency>
+				
+		<dependency>
+			<groupId>com.googlecode.json-simple</groupId>
+			<artifactId>json-simple</artifactId>
+			<version>1.1</version>
+		</dependency>
+		<!-- //file upload -->
+		
 		<!-- 암호화 -->
 		<dependency>
 		  <groupId>org.springframework.security</groupId>

--- a/CommunitySite/src/main/java/com/portfolio/site/common/util/SummerNoteImageUpload.java
+++ b/CommunitySite/src/main/java/com/portfolio/site/common/util/SummerNoteImageUpload.java
@@ -1,0 +1,48 @@
+package com.portfolio.site.common.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+import org.apache.commons.io.FileUtils;
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@Controller
+public class SummerNoteImageUpload {
+
+	@PostMapping(value="/uploadSummernoteImageFile", produces = "application/json")
+	@ResponseBody
+	public JSONObject uploadSummernoteImageFile(@RequestParam("file") MultipartFile multipartFile) {
+		
+		JSONObject jsonObject = new JSONObject();
+		
+		String fileRoot = "/home/kimdw/pt_img/";	//저장될 외부 파일 경로
+		String originalFileName = multipartFile.getOriginalFilename();	//오리지날 파일명
+		String extension = originalFileName.substring(originalFileName.lastIndexOf("."));	//파일 확장자
+				
+		String savedFileName = UUID.randomUUID() + extension;	//저장될 파일 명
+		
+		File targetFile = new File(fileRoot + savedFileName);	
+		
+		try {
+			InputStream fileStream = multipartFile.getInputStream();
+			FileUtils.copyInputStreamToFile(fileStream, targetFile);	//파일 저장
+			jsonObject.put("url", "/upload/"+savedFileName);
+			jsonObject.put("responseCode", "success");
+				
+		} catch (IOException e) {
+			FileUtils.deleteQuietly(targetFile);	//저장된 파일 삭제
+			jsonObject.put("responseCode", "error");
+			e.printStackTrace();
+		}
+		
+		return jsonObject;
+	}
+}

--- a/CommunitySite/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/CommunitySite/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -39,6 +39,8 @@
 	
 	<context:component-scan base-package="com.portfolio.site" />
 	
-	
+	<beans:bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
+  		<beans:property name="maxUploadSize" value="5120000"></beans:property>
+	</beans:bean>
 	
 </beans:beans>

--- a/CommunitySite/src/main/webapp/WEB-INF/views/board/tech/write.jsp
+++ b/CommunitySite/src/main/webapp/WEB-INF/views/board/tech/write.jsp
@@ -105,8 +105,53 @@ $(function() {
 		fontNames: ['Arial', 'Arial Black', 'Comic Sans MS', 'Courier New','맑은 고딕','궁서','굴림체','굴림','돋음체','바탕체'],
 		 // 추가한 폰트사이즈
 		fontSizes: ['8','9','10','11','12','14','16','18','20','22','24','28','30','36','50','72'],
+		// onImageUpload callback
+		callbacks: {
+		    onImageUpload: function(files) {
+		    	console.log("callbacks files ======> ", files);
+		    },
+		    onPaste: function (e) {
+				var clipboardData = e.originalEvent.clipboardData;
+				console.log("clipboardData =====>",clipboardData);
+				if (clipboardData && clipboardData.items && clipboardData.items.length) {
+					var item = clipboardData.items[0];
+					if (item.kind === 'file' && item.type.indexOf('image/') !== -1) {
+						e.preventDefault();
+					}
+				}
+			}
+		  }
   	});
+
+	// summernote.image.upload
+	$('#summernote').on('summernote.image.upload', function(we, files) {
+		console.log("we ======> ", we);
+		console.log("files ======> ", files);
+		console.log("this =======> ",this);
+		
+		var data = new FormData();
+		data.append("file", files[0]);
+		console.log('data ======++> ', files[0]);
+		$.ajax({
+			data : data,
+			type : "POST",
+			url : "/uploadSummernoteImageFile",
+			contentType : false,
+			processData : false,
+			success : function(data) {
+				console.log('success : ',data);
+	        	//항상 업로드된 파일의 url이 있어야 한다.
+				//$(this).summernote('insertImage', data.url);
+				$('#summernote').summernote('insertImage', data.url);
+			},
+			error:function(request,status,error){
+			    console.log("code:"+request.status+"\n"+"message:"+request.responseText+"\n"+"error:"+error);
+		   }
+		});
+	});
+
 });
+
 
 
 </script>


### PR DESCRIPTION
이슈내용: base64로 저장시 용량이 거대해짐으로 뻗는 현상 발생
해결방법: 기존 DB에 base64로 저장되던 로직을 외부경로에 파일 저장하여
가져오는 방식으로 변환(5MB로 제한둠)

외부경로에 파일 저장시 톰캣에 외부경로 추가해야함.
<Context docBase="/외부경로/" path="/upload/" reloadable="false" />